### PR TITLE
pathlib.Path for OutImage

### DIFF
--- a/.github/workflows/testing-and-coverage.yml
+++ b/.github/workflows/testing-and-coverage.yml
@@ -30,10 +30,11 @@ jobs:
         python -m pip install --upgrade pip
         pip install -e .[dev]
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
-    # - name: Run unit tests with pytest
-    #   run: |
-    #     python -m pytest --cov=pyimcom --cov-report=xml
-    # - name: Upload coverage report to codecov
-    #   uses: codecov/codecov-action@v5
-    #   with:
-    #     token: ${{ secrets.CODECOV_TOKEN }}
+    - name: Run unit tests with pytest
+      run: |
+        python -m pytest --cov=pyimcom --cov-report=xml
+    - name: Upload coverage report to codecov
+      uses: codecov/codecov-action@v5
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
+        slug: Roman-HLIS-Cosmology-PIT/pyimcom

--- a/README.rst
+++ b/README.rst
@@ -1,3 +1,5 @@
+.. image:: https://codecov.io/gh/Roman-HLIS-Cosmology-PIT/pyimcom/graph/badge.svg?token=GLM6LWD3F7
+
 PyIMCOM: Image combination package
 ##################################
 

--- a/docs/output_README.rst
+++ b/docs/output_README.rst
@@ -35,9 +35,9 @@ There are several options for reading PyIMCOM output files. From "lowest" to "hi
     # here fout is the file name that we want to read
     my_block = OutImage(fout)
     # extracts a layer: 'SCI' is the science image, or you can use other layer names
-    sci_image = im.get_coadded_layer('SCI')
+    sci_image = my_block.get_coadded_layer('SCI')
     # extracts a metadata map
-    fidelity_map = im.get_output_map('FIDELITY') # options are: 'FIDELITY', 'SIGMA', 'KAPPA', 'INTWTSUM', 'EFFCOVER'
+    fidelity_map = my_block.get_output_map('FIDELITY') # options are: 'FIDELITY', 'SIGMA', 'KAPPA', 'INTWTSUM', 'EFFCOVER'
 
 * The ``pyimcom.meta.distortimage.MetaMosaic`` class is the highest-level interface and constructs a sub-mosaic
   from the 3x3 set of blocks centered on the specified file. It can be subarrayed, sheared, masked, etc.::

--- a/src/pyimcom/analysis.py
+++ b/src/pyimcom/analysis.py
@@ -45,7 +45,7 @@ class OutImage:
 
     Parameters
     ----------
-    fpath : str
+    fpath : str or str-like
         Path to the output FITS file.
     cfg : Config, optional
         Configuration used for this output image.
@@ -112,6 +112,7 @@ class OutImage:
         return hdu_names
 
     def __init__(self, fpath: str, cfg: Config = None, hdu_names: list[str] = None) -> None:
+        fpath = str(fpath)
         self.fpath = fpath
 
         # Get file indices.

--- a/src/pyimcom/compress/compressutils.py
+++ b/src/pyimcom/compress/compressutils.py
@@ -359,7 +359,7 @@ def _parser(fname):
 
     Parameters
     ----------
-    fname : str
+    fname : str or str-like
         Regular file name (not including ^) or regular expression.
 
     Returns
@@ -368,6 +368,8 @@ def _parser(fname):
         The formatted file name.
 
     """
+
+    fname = str(fname)  # converts other objects, e.g., pathlib.Path, to a string
 
     # normal file name: nothing to be done
     if "^" not in fname:
@@ -396,7 +398,7 @@ def ReadFile(fname):
 
     Parameters
     ----------
-    fname : str
+    fname : str or str-like
         File name to read.
 
     Notes


### PR DESCRIPTION
Added the ability for an ``OutImage`` to be instantiated with a ``pathlib.Path``; is part of addressing #36 , although I want to make ``pathlib.Path`` available for a few more objects before closing the issue.

Also added a unit test for this feature and associated code coverage test.